### PR TITLE
Add .github/codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 #####################################################
 #
-# List of approvers for OpenTelemetry Collector
+# Team of approvers for this project.
 #
 #####################################################
 #

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+#####################################################
+#
+# List of approvers for OpenTelemetry Collector
+#
+#####################################################
+#
+# Learn about membership in OpenTelemetry community:
+#  https://github.com/open-telemetry/community/blob/main/community-membership.md
+#
+#
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+#
+
+* @open-telemetry/proto-go-approvers/


### PR DESCRIPTION
Add codeowners file that auto-assigns @open-telemetry/proto-go-approvers.