### PR TITLE
Release v1.3.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "opentelemetry-proto"]
 	path = opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto
-	branch = v1.2.0
+	branch = v1.3.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   all:
-    version: v1.2.0
+    version: v1.3.0
     modules:
       - go.opentelemetry.io/proto
       - go.opentelemetry.io/proto/otlp


### PR DESCRIPTION
Release of the [v1.3.0][otlp] version of the OTLP.

[otlp]: https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v1.3.0