### PR TITLE
Clean the gen folder before running tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,12 +155,16 @@ toolchain-check:
 			exit 1; \
 	fi
 
+.PHONY: clean-gen
+clean-gen:
+	rm -rf $(GEN_TEMP_DIR)
+
 .PHONY: clean
-clean:
-	rm -rf $(GEN_TEMP_DIR) $(OTLP_OUTPUT_DIR)/*/ $(OTLPSLIM_OUTPUT_DIR)/*/
+clean: clean-gen
+	rm -rf $(OTLP_OUTPUT_DIR)/*/ $(OTLPSLIM_OUTPUT_DIR)/*/
 
 .PHONY: go-mod-tidy
-go-mod-tidy: $(ALL_GO_MOD_DIRS:%=go-mod-tidy/%)
+go-mod-tidy: clean-gen $(ALL_GO_MOD_DIRS:%=go-mod-tidy/%)
 go-mod-tidy/%: DIR=$*
 go-mod-tidy/%:
 	@echo "$(GO) mod tidy in $(DIR)" \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,3 @@
 module go.opentelemetry.io/proto
 
 go 1.22.0
-
-require (
-	go.opentelemetry.io/proto/otlp v1.3.1
-	google.golang.org/protobuf v1.35.2
-)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,0 @@
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-go.opentelemetry.io/proto/otlp v1.3.1 h1:TrMUixzpM0yuc/znrFTP9MMRh8trP93mkCiDVeXrui0=
-go.opentelemetry.io/proto/otlp v1.3.1/go.mod h1:0X1WI4de4ZsLrrJNLAQbFeLCm3T7yBkR0XqQ7niQU+8=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.35.2 h1:8Ar7bF+apOIoThw1EdZl0p1oWvMqTHmpA2fRTyZO8io=
-google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=


### PR DESCRIPTION
If the `gen` folder has generated code, then `go mod tidy` considers that as code it needs to include within the package.
This causes issues in https://github.com/open-telemetry/opentelemetry-proto-go/pull/193, because packages have been renamed. So they can't be found in published releases anymore.

This also pollutes the root `go.mod` with dependencies we don't actually need.