### PR TITLE
Remove compat from go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ $(error Submodule at $(OTEL_PROTO_SUBMODULE) is not checked out, use "git submod
 endif
 
 GO                := go
-GO_VERSION        := $(shell grep "^go " go.mod | sed 's/go //')
 GO_MOD_ROOT       := go.opentelemetry.io/proto
 ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
 OTEL_GO_MOD_DIRS := $(filter-out $(TOOLS_MOD_DIR), $(ALL_GO_MOD_DIRS))
@@ -165,7 +164,7 @@ go-mod-tidy/%: DIR=$*
 go-mod-tidy/%:
 	@echo "$(GO) mod tidy in $(DIR)" \
 		&& cd $(DIR) \
-		&& $(GO) mod tidy -compat=$(GO_VERSION)
+		&& $(GO) mod tidy
 
 test: $(OTEL_GO_MOD_DIRS:%=test/%)
 test/%: DIR=$*

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(error Submodule at $(OTEL_PROTO_SUBMODULE) is not checked out, use "git submod
 endif
 
 GO                := go
-GO_VERSION        := 1.17
+GO_VERSION        := $(shell grep "^go " go.mod | sed 's/go //')
 GO_MOD_ROOT       := go.opentelemetry.io/proto
 ALL_GO_MOD_DIRS := $(shell find . -type f -name 'go.mod' -exec dirname {} \; | sort)
 OTEL_GO_MOD_DIRS := $(filter-out $(TOOLS_MOD_DIR), $(ALL_GO_MOD_DIRS))
@@ -165,7 +165,7 @@ go-mod-tidy/%: DIR=$*
 go-mod-tidy/%:
 	@echo "$(GO) mod tidy in $(DIR)" \
 		&& cd $(DIR) \
-		&& $(GO) mod tidy -compat=1.21
+		&& $(GO) mod tidy -compat=$(GO_VERSION)
 
 test: $(OTEL_GO_MOD_DIRS:%=test/%)
 test/%: DIR=$*


### PR DESCRIPTION
This is a follow up to https://github.com/open-telemetry/opentelemetry-proto-go/pull/205 where the Go version was updated. The proposed change makes sure, that the same Go version is used in various steps.

If https://github.com/open-telemetry/opentelemetry-proto-go/pull/212 is accepted and merged, this PR can be updated to use [otlp/go.mod](https://github.com/open-telemetry/opentelemetry-proto-go/blob/main/otlp/go.mod) as source of turth instead of [go.mod](https://github.com/open-telemetry/opentelemetry-proto-go/blob/main/go.mod).