### PR TITLE
Relax the minimum required Go version further

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.opentelemetry.io/proto
 
-go 1.22.0
+go 1.22

--- a/otlp/go.mod
+++ b/otlp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/proto/otlp
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.0

--- a/slim/otlp/go.mod
+++ b/slim/otlp/go.mod
@@ -1,6 +1,6 @@
 module go.opentelemetry.io/proto/slim/otlp
 
-go 1.22.0
+go 1.22
 
 require google.golang.org/protobuf v1.36.3
 


### PR DESCRIPTION
Thanks to https://github.com/grpc-ecosystem/grpc-gateway/pull/5094

CC @codeboten 