### PR TITLE
Standardize sections listing maintainer, approver, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,17 @@ This project is tested on the following systems.
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.
+
+## Maintainers
+
+- [Mike Goldsmith](https://github.com/MikeGoldsmith), Honeycomb
+- [Tyler Yahn](https://github.com/MrAlias), Splunk
+- [OpenTelemetry Go Maintainers](https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#maintainers)
+
+For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
+
+## Approvers
+
+- [Robert Pająk](https://github.com/pellared), Splunk
+
+For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ are made for those systems currently.
 ## Maintainers
 
 - [Mike Goldsmith](https://github.com/MikeGoldsmith), Honeycomb
-- [Tyler Yahn](https://github.com/MrAlias), Splunk
 - [OpenTelemetry Go Maintainers](https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#maintainers)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).

--- a/README.md
+++ b/README.md
@@ -82,6 +82,6 @@ For more information about the maintainer role, see the [community repository](h
 
 ## Approvers
 
-- [Robert Pająk](https://github.com/pellared), Splunk
+- [OpenTelemetry Go Approvers](https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#approvers)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ are made for those systems currently.
 
 ## Maintainers
 
-- [Mike Goldsmith](https://github.com/MikeGoldsmith), Honeycomb
 - [OpenTelemetry Go Maintainers](https://github.com/open-telemetry/opentelemetry-go/blob/main/CONTRIBUTING.md#maintainers)
+- [Mike Goldsmith](https://github.com/MikeGoldsmith), Honeycomb
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/community/issues/2830

This is what it looks like currently at least: https://github.com/open-telemetry/admin/blob/930675168784f6965dfe177c96b5603998e3d5f8/repo-opentelemetry-proto-go.tf#L17-L30

Would you like to remove @open-telemetry/proto-go-maintainers and @open-telemetry/proto-go-approvers, and just have this repo maintained/approved by @open-telemetry/go-maintainers and @open-telemetry/go-maintainers? (this is a common pattern for some repos to not their own dedicated maintainer/approver teams)

It's ok as-is too. I think it's the only repo I've seen though that blends the two approaches (having its own maintainer team _and_ referencing another maintainer team).