### PR TITLE
Add go-approvers and go-maintainers to codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,6 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @open-telemetry/proto-go-approvers
+* @open-telemetry/proto-go-approvers @open-telemetry/go-approvers
 
-.github/CODEOWNERS @open-telemetry/proto-go-maintainers 
+.github/CODEOWNERS @open-telemetry/proto-go-maintainers @open-telemetry/go-maintainers


### PR DESCRIPTION
Which should hopefully unblock merging PRs.
See https://github.com/open-telemetry/opentelemetry-proto-go/pull/341