### PR TITLE
Release v1.7.1 and v0.0.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -20,7 +20,7 @@ module-sets:
       - go.opentelemetry.io/proto/otlp
       - go.opentelemetry.io/proto/slim/otlp
   unstable:
-    version: 0.0.0
+    version: v0.0.1
     modules:
       - go.opentelemetry.io/proto/otlp/profiles/v1development
       - go.opentelemetry.io/proto/otlp/collector/profiles/v1development

--- a/versions.yaml
+++ b/versions.yaml
@@ -14,7 +14,7 @@
 
 module-sets:
   all:
-    version: v1.7.0
+    version: v1.7.1
     modules:
       - go.opentelemetry.io/proto
       - go.opentelemetry.io/proto/otlp


### PR DESCRIPTION
This release does not match a proto release.
Its intention is to release v0.0.1 of the unstable profiles module, so the module is indeed released.