### PR TITLE
Push both the stable and unstable modules in push-tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ REMOTE ?= upstream
 .PHONY: push-tags
 push-tags: | $(MULTIMOD)
 	$(MULTIMOD) verify
-	for module in all unstable; do \
+	for module in stable unstable; do \
 		for tag in `$(MULTIMOD) tag -m $$module -c ${COMMIT} --print-tags | grep -v "Using"`; do \
 			echo "pushing tag $$tag"; \
 			git push ${REMOTE} $$tag; \

--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,9 @@ REMOTE ?= upstream
 .PHONY: push-tags
 push-tags: | $(MULTIMOD)
 	$(MULTIMOD) verify
-	set -e; for tag in `$(MULTIMOD) tag -m all -c ${COMMIT} --print-tags | grep -v "Using" `; do \
-		echo "pushing tag $${tag}"; \
-		git push ${REMOTE} $${tag}; \
-	done;
+	for module in all unstable; do \
+		for tag in `$(MULTIMOD) tag -m $$module -c ${COMMIT} --print-tags | grep -v "Using"`; do \
+			echo "pushing tag $$tag"; \
+			git push ${REMOTE} $$tag; \
+		done; \
+	done

--- a/versions.yaml
+++ b/versions.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 module-sets:
-  all:
+  stable:
     version: v1.7.1
     modules:
       - go.opentelemetry.io/proto


### PR DESCRIPTION
Pushing tags needs to look at both the stable and unstable modules.